### PR TITLE
Split up docker-compose config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.vscode
+.npmrc
+.git    
+node_modules
+docker-compose
+postgresql_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
 FROM node:8
 
 WORKDIR /usr/src/app
-COPY . .
+
+COPY package.json package.json
+
 RUN npm install
 RUN npm prune --production
 RUN mkdir -p log
+
+# Copy files after installation
+COPY config config
+COPY models models
+COPY public public
+COPY service service
+COPY util util
+COPY web web
+COPY index.js index.js
+COPY express.js express.js
+COPY sequelize.js sequelize.js
+
 ENV NODE_ENV production
 
 CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ module.exports = {
   'secretOrKey': 'mellon'
 }
 ```
+
+2. Start the database and pgAdmin: `docker-compose --f docker-compose-dev.yml up`
+
+3. Run `npm install` and then `npm start` and gondolin will be available at `http://localhost:3000`.
+
+
+## Run via docker / docker-compose
+
+```
+docker build -t gondolin-server .
+
+docker-compose up
+```

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,5 +14,5 @@ services:
     ports:
       - "5050:80"
     environment:
-      PGADMIN_DEFAULT_PASSWORD: SuperSecret
-      PGADMIN_DEFAULT_EMAIL: user@domain.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL: admin

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,5 @@
 version: '3'
 services:
-  gondolin-server:
-    image: gondolin-server
-    ports:
-      - "3000:3000"
   gondolin-postgis:
     image: mdillon/postgis:10-alpine
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,5 @@ services:
     ports:
       - "5050:80"
     environment:
-      PGADMIN_DEFAULT_PASSWORD: SuperSecret
-      PGADMIN_DEFAULT_EMAIL: user@domain.com
+      PGADMIN_DEFAULT_PASSWORD: admin 
+      PGADMIN_DEFAULT_EMAIL: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,18 @@
 version: '3'
 services:
-  shogun-postgis:
+  gondolin-postgis:
     image: mdillon/postgis:10-alpine
     ports:
-      - 5555:5432
+      - "5555:5432"
     environment:
       POSTGRES_USER: gondolin
       POSTGRES_PASSWORD: gondolin
     volumes:
       - ./postgresql_data:/var/lib/postgresql/data:Z
+  gondolin-pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - "5050:80"
+    environment:
+      PGADMIN_DEFAULT_PASSWORD: SuperSecret
+      PGADMIN_DEFAULT_EMAIL: user@domain.com


### PR DESCRIPTION
- creates separate `docker-compose-dev.yml`
- adds pgadmin to the development compose config