### PR TITLE
Downgrade sequelize to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "reflect-metadata": "0.1.13",
     "request": "2.88.0",
     "request-promise-native": "1.0.7",
-    "sequelize": "5.1.1",
+    "sequelize": "4.43.0",
     "sequelize-cli": "5.4.0",
     "sequelize-typescript": "1.0.0-alpha.4",
     "ts-node": "8.0.3",


### PR DESCRIPTION
This downgrades sequelize to v4 as v5 needs several updates on the Code / API.