### PR TITLE
Ignore sequelize updates (for now)

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,6 @@
+{
+  "ignore": [
+    "sequelize"
+  ]
+}
+


### PR DESCRIPTION
As sequelize can't be updated to v5 right now, we'll ignore greenkeeper update notes.

Please review and merge @KaiVolland.