### PR TITLE
Fixes sequelize logging

### DIFF
--- a/config/database.ts
+++ b/config/database.ts
@@ -1,4 +1,4 @@
-// import logger from './logger';
+import logger from './logger';
 
 export default {
   development: {
@@ -10,9 +10,10 @@ export default {
     port: 5555,
     protocol: 'postgres',
     schema: 'gondolin',
-    databaseVersion: '10.2.5'
-    // TODO Does currently not work... Fix it
-    // logging: logger.sequelize
+    databaseVersion: '10.2.5',
+    logging: (msg) => {
+      logger.log('sequelize', msg);
+    }
   },
   production: {
     database: 'gondolin',

--- a/config/logger.ts
+++ b/config/logger.ts
@@ -22,15 +22,6 @@ const levels = {
   error: 0
 };
 
-winston.addColors({
-  silly: 'magenta',
-  sequelize: 'magenta',
-  debug: 'cyan',
-  info: 'green',
-  warn: 'yellow',
-  error: 'bold red'
-});
-
 const consoleFormat = format.printf((info) => {
   const timestamp = moment().format('DD.MM.YY hh:mm:ss.SSS');
   return `${timestamp} [${info.level}]: ${info.message}`;
@@ -59,6 +50,16 @@ const logger: winston.Logger = createLogger({
 
 // If we're not in production then log to the `console`
 if (environment !== 'production') {
+
+  winston.addColors({
+    silly: 'bold white',
+    sequelize: 'bold magenta',
+    debug: 'bold cyan',
+    info: 'bold green',
+    warn: 'bold yellow',
+    error: 'bold red'
+  });
+
   logger.add(new transports.Console({
     format: format.combine(
       format.colorize(),


### PR DESCRIPTION
This fixes the logging of `sequelize`.
Output is now passed to winston again.

closes #4 