### PR TITLE
Fix require of graphqlHTTP in index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 const environment = process.env.NODE_ENV || 'production';
-const graphqlHTTP = require('express-graphql');
+const graphqlHTTP = require('express-graphql').graphqlHTTP;
 
 // Setup Sequelize
 require('./sequelize.ts');


### PR DESCRIPTION
On a cleaned setup with Node.js v10 I had to adjust the require statement for `graphqlHTTP` in `index.ts` otherwise the gondolin server does not start.